### PR TITLE
Add SQLite fallback, env-based Jira config, and console preview mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
 # Copy this file to .env and fill in the values for your environment.
 # The application automatically loads variables from .env when the package is imported.
+JIRA_BASE_URL=https://your-jira.example.com
+JIRA_CA_BUNDLE=/path/to/root_certificate.pem
 JIRA_PAT=your_jira_pat
 DATABASE_URL=postgresql://username:password@localhost:5432/jira
+JIRA_PRINT_ONLY=false

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ cover/
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
+jira.db
 
 # Flask stuff:
 instance/

--- a/README.md
+++ b/README.md
@@ -40,12 +40,18 @@ incremental operation, typed modules, and ease of local testing.
    cp .env.example .env
    ```
 
-   The application loads this file automatically on startup.  Populate the
-   following variables with your credentials:
+  The application loads this file automatically on startup.  Populate the
+  following variables with values that match your environment:
 
-   - `JIRA_PAT`: Personal access token used for Jira authentication.
-   - `DATABASE_URL`: PostgreSQL connection string that points to the reporting
-     database where the schema from `sql/schema.sql` has been applied.
+  - `JIRA_BASE_URL`: Base URL for your Jira Data Center instance.
+  - `JIRA_CA_BUNDLE`: Optional path to a PEM encoded root certificate used to
+    verify HTTPS requests.  Leave empty to use the system trust store.
+  - `JIRA_PAT`: Personal access token used for Jira authentication.
+  - `DATABASE_URL`: PostgreSQL connection string that points to the reporting
+    database where the schema from `sql/schema.sql` has been applied.
+  - `JIRA_PRINT_ONLY`: Optional flag (`true`/`false`) that forces the CLI to
+    skip all database writes and instead print each transformed issue to the
+    console.  Defaults to `false` when unset.
 
 3. **Review configuration**
 
@@ -72,6 +78,14 @@ incremental operation, typed modules, and ease of local testing.
    The incremental job resumes from the stored cursor and applies the safety
    skew to avoid missing updates near the resume boundary.  Rerunning the sync
    after an interruption will continue from the last committed page.
+
+   Both backfill and sync accept a `--local-db` flag that bypasses the
+   PostgreSQL loader and instead writes every extracted page to a local
+   `jira.db` SQLite file alongside resumable cursor checkpoints.  Use
+   `--local-db-path` to override the destination file if required.  When
+   `JIRA_PRINT_ONLY=true` is present in the environment, the commands ignore the
+   `--local-db` flag, stream each page to standard output, and keep cursor state
+   in-memory so nothing is persisted to disk.
 
 6. **Inspect data or metadata**
 

--- a/config/etl.yml
+++ b/config/etl.yml
@@ -1,6 +1,6 @@
 jira:
-  base_url: "https://globaljira.example.com"
-  ca_bundle: null
+  base_url_env: "JIRA_BASE_URL"
+  ca_bundle_env: "JIRA_CA_BUNDLE"
   pat_env: "JIRA_PAT"
   page_size: 100
   parallelism: 2
@@ -36,3 +36,7 @@ windows:
 
 database:
   dsn_env: "DATABASE_URL"
+
+output:
+  print_only_env: "JIRA_PRINT_ONLY"
+  print_only: false

--- a/scripts/backfill.py
+++ b/scripts/backfill.py
@@ -3,15 +3,15 @@ from __future__ import annotations
 
 import argparse
 import logging
-from typing import List
+from pathlib import Path
 
 from jira_extraction.config import AppConfig, load_config
 from jira_extraction.extract import stream_scope
 from jira_extraction.http_client import JiraHTTPClient
 from jira_extraction.jira_api import JiraAPI
-from jira_extraction.load import PostgresLoader
+from jira_extraction.load import ConsoleLoader, PostgresLoader, SQLiteLoader
 from jira_extraction.logging_setup import configure_logging
-from jira_extraction.state_store import PostgresStateStore
+from jira_extraction.state_store import InMemoryStateStore, PostgresStateStore, SQLiteStateStore
 from jira_extraction.transform import transform_issue
 
 
@@ -21,6 +21,16 @@ LOGGER = logging.getLogger(__name__)
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run an initial Jira ETL backfill")
     parser.add_argument("--config", default="config/etl.yml", help="Path to the ETL configuration file")
+    parser.add_argument(
+        "--local-db",
+        action="store_true",
+        help="Write data to a local jira.db SQLite file instead of the configured database",
+    )
+    parser.add_argument(
+        "--local-db-path",
+        default="jira.db",
+        help="Destination SQLite file used when --local-db is enabled",
+    )
     return parser.parse_args()
 
 
@@ -28,14 +38,26 @@ def ensure_connectivity(api: JiraAPI) -> None:
     api.get_myself()
 
 
-def run_backfill(config: AppConfig) -> None:
-    if config.database is None:
-        msg = "Database configuration is required for backfill"
-        raise RuntimeError(msg)
+def run_backfill(config: AppConfig, *, use_local_db: bool = False, local_db_path: Path | str = "jira.db") -> None:
+    if config.output.should_print_only():
+        if use_local_db:
+            LOGGER.warning("--local-db flag ignored because console output mode is enabled")
+        LOGGER.info("Printing backfill output to console; no data will be persisted")
+        store = InMemoryStateStore()
+        loader = ConsoleLoader()
+    elif use_local_db:
+        path = Path(local_db_path)
+        LOGGER.info("Writing backfill output to local SQLite database", extra={"path": str(path)})
+        store = SQLiteStateStore(path)
+        loader = SQLiteLoader(path)
+    else:
+        if config.database is None:
+            msg = "Database configuration is required for backfill"
+            raise RuntimeError(msg)
 
-    dsn = config.database.get_dsn()
-    store = PostgresStateStore(dsn)
-    loader = PostgresLoader(dsn)
+        dsn = config.database.get_dsn()
+        store = PostgresStateStore(dsn)
+        loader = PostgresLoader(dsn)
 
     with JiraHTTPClient(base_url=config.jira.base_url, pat=config.jira.get_pat(), ca_bundle=config.jira.ca_bundle) as client:
         api = JiraAPI(client)
@@ -60,7 +82,7 @@ def main() -> None:
     args = parse_args()
     configure_logging()
     config = load_config(args.config)
-    run_backfill(config)
+    run_backfill(config, use_local_db=args.local_db, local_db_path=args.local_db_path)
 
 
 if __name__ == "__main__":

--- a/scripts/sync.py
+++ b/scripts/sync.py
@@ -3,14 +3,15 @@ from __future__ import annotations
 
 import argparse
 import logging
+from pathlib import Path
 
 from jira_extraction.config import AppConfig, load_config
 from jira_extraction.extract import stream_scope
 from jira_extraction.http_client import JiraHTTPClient
 from jira_extraction.jira_api import JiraAPI
-from jira_extraction.load import PostgresLoader
+from jira_extraction.load import ConsoleLoader, PostgresLoader, SQLiteLoader
 from jira_extraction.logging_setup import configure_logging
-from jira_extraction.state_store import PostgresStateStore
+from jira_extraction.state_store import InMemoryStateStore, PostgresStateStore, SQLiteStateStore
 from jira_extraction.transform import transform_issue
 
 LOGGER = logging.getLogger(__name__)
@@ -19,6 +20,16 @@ LOGGER = logging.getLogger(__name__)
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run the incremental Jira sync")
     parser.add_argument("--config", default="config/etl.yml", help="Path to the ETL configuration file")
+    parser.add_argument(
+        "--local-db",
+        action="store_true",
+        help="Write data to a local jira.db SQLite file instead of the configured database",
+    )
+    parser.add_argument(
+        "--local-db-path",
+        default="jira.db",
+        help="Destination SQLite file used when --local-db is enabled",
+    )
     return parser.parse_args()
 
 
@@ -26,14 +37,26 @@ def ensure_connectivity(api: JiraAPI) -> None:
     api.get_myself()
 
 
-def run_sync(config: AppConfig) -> None:
-    if config.database is None:
-        msg = "Database configuration is required for sync"
-        raise RuntimeError(msg)
+def run_sync(config: AppConfig, *, use_local_db: bool = False, local_db_path: Path | str = "jira.db") -> None:
+    if config.output.should_print_only():
+        if use_local_db:
+            LOGGER.warning("--local-db flag ignored because console output mode is enabled")
+        LOGGER.info("Printing sync output to console; no data will be persisted")
+        store = InMemoryStateStore()
+        loader = ConsoleLoader()
+    elif use_local_db:
+        path = Path(local_db_path)
+        LOGGER.info("Writing sync output to local SQLite database", extra={"path": str(path)})
+        store = SQLiteStateStore(path)
+        loader = SQLiteLoader(path)
+    else:
+        if config.database is None:
+            msg = "Database configuration is required for sync"
+            raise RuntimeError(msg)
 
-    dsn = config.database.get_dsn()
-    store = PostgresStateStore(dsn)
-    loader = PostgresLoader(dsn)
+        dsn = config.database.get_dsn()
+        store = PostgresStateStore(dsn)
+        loader = PostgresLoader(dsn)
 
     with JiraHTTPClient(base_url=config.jira.base_url, pat=config.jira.get_pat(), ca_bundle=config.jira.ca_bundle) as client:
         api = JiraAPI(client)
@@ -58,7 +81,7 @@ def main() -> None:
     args = parse_args()
     configure_logging()
     config = load_config(args.config)
-    run_sync(config)
+    run_sync(config, use_local_db=args.local_db, local_db_path=args.local_db_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a SQLite-based loader/state store so backfill and sync can write to a local `jira.db`
- load the Jira base URL and CA bundle path from environment variables and document the new settings
- expose `--local-db`/`--local-db-path` CLI flags, add sample env values, and ignore the generated database file
- add a console-only output mode controlled by the `JIRA_PRINT_ONLY` environment variable that streams transformed issues without persisting them

## Testing
- python -m compileall src scripts

------
https://chatgpt.com/codex/tasks/task_e_68d6a95e12948325810bc4f2c3eb22ba